### PR TITLE
Initialize GitHub Pages site structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# adeglon.github.io
-Agnes Deglon Github Pages
+# Agnes Deglon Blog
+
+This repository hosts the source for Agnes Deglon's GitHub Pages blog.
+
+## Getting started
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/adeglon/adeglon.github.io.git
+   cd adeglon.github.io
+   ```
+
+2. **Edit the site**
+
+   - Web pages live in the `web/` directory. Start by editing `web/index.html`.
+   - Add additional pages or assets inside `web/` as the blog grows.
+
+3. **Preview locally**
+
+   To preview with the configured GitHub Pages theme:
+
+   ```bash
+   bundle install
+   bundle exec jekyll serve
+   ```
+
+   Visit `http://localhost:4000` in your browser.
+
+4. **Publish**
+
+   Commit your changes and push to the `main` branch. GitHub Pages will rebuild the site automatically.
+
+## Customization
+
+- Site configuration lives in `_config.yml`. It currently uses the `minima` theme. Explore other [GitHub Pages themes](https://pages.github.com/themes/) by updating this file.
+- Follow common best practices: include descriptive meta tags, optimize images, and keep external dependencies up to date.
+
+## Directory structure
+
+```text
+/
+├── _config.yml         # GitHub Pages configuration
+├── README.md           # Project overview and instructions
+└── web/                # Website pages
+    └── index.html      # Landing page
+```

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: Agnes Deglon Blog
+description: Personal blog of Agnes Deglon
+theme: minima

--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-<h1>Hello World!</h1>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Blog posts and updates from Agnes Deglon." />
+  <title>Agnes Deglon's Blog</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Agnes Deglon</a>
+    </div>
+  </nav>
+  <main class="container my-5">
+    <h1>Welcome to Agnes Deglon's Blog</h1>
+    <p class="lead">This site is under construction. Stay tuned for upcoming posts.</p>
+  </main>
+  <footer class="text-center py-3">
+    <p>&copy; <span id="year"></span> Agnes Deglon</p>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `web/` directory with bootstrap-themed landing page
- configure GitHub Pages via `_config.yml`
- document setup and best practices in `README`

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cfe38e920832abed87624a9965bd7