### PR TITLE
Add repository guidelines and codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS
+
+This repository hosts the public GitHub Pages site for **Agnes Deglon**.
+
+## Guidelines
+- The site is available at <https://adeglon.github.io/> and is also served via the custom domain <https://agnesdeglon.com/> (see `CNAME`).
+- GitHub Pages builds from the `docs/` directory. Edit site content there.
+- This repository is public. **Do not commit confidential or personally identifiable information.**
+- Before committing changes, run:
+  ```bash
+  bundle install
+  bundle exec jekyll build --source docs
+  ```
+  to ensure the site builds successfully.
+
+## Commit expectations
+- Keep commits focused and descriptive.
+- Do not create new branches.
+

--- a/codex.md
+++ b/codex.md
@@ -1,0 +1,18 @@
+# Codex
+
+This repository contains the source for Agnes Deglon's public website.
+
+- **Primary URL:** <https://adeglon.github.io/>
+- **Custom domain:** <https://agnesdeglon.com/> (configured via `CNAME`).
+- **Content root:** GitHub Pages serves files from the `docs/` directory.
+- **Repository visibility:** Public. Avoid committing confidential or personally identifiable information.
+
+## Development notes
+- Pages and assets should live under `docs/`.
+- To preview locally:
+  ```bash
+  bundle install
+  bundle exec jekyll serve --source docs
+  ```
+- Commit changes directly to the `main` branch; GitHub Pages will rebuild automatically.
+


### PR DESCRIPTION
## Summary
- Document repository purpose and usage in new AGENTS.md
- Add codex.md outlining public site, custom domain, and development notes

## Testing
- `bundle install`
- `bundle exec jekyll build --source docs`


------
https://chatgpt.com/codex/tasks/task_e_689d049c14f0832ab3e462648dff1d08